### PR TITLE
Added tests for checking python side type of values of a maps

### DIFF
--- a/_examples/ifxmap/maps.go
+++ b/_examples/ifxmap/maps.go
@@ -1,0 +1,32 @@
+// Copyright 2015 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ifxmap
+
+import (
+	//"sort"
+)
+
+type TestStruct struct {
+	Value int
+}
+ 
+func New() map[string]interface{} {
+	retval := make(map[string]interface{})
+
+	retval["float"] = 3.14159
+	retval["string"] = "sample"
+	retval["int"] = 2
+	retval["bool"] = true
+	retval["struct"] = TestStruct {
+		Value: 6,
+	}
+
+	structPtr := TestStruct {
+		Value: 12, 
+	}
+	retval["structPtr"] = &structPtr 
+
+	return retval
+}

--- a/_examples/ifxmap/test.py
+++ b/_examples/ifxmap/test.py
@@ -1,0 +1,30 @@
+# Copyright 2017 The go-python Authors.  All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+from __future__ import print_function
+import ifxmap
+
+im = ifxmap.New()
+
+assert(isinstance(im["float"], float))
+assert(im["float"] == 3.14159)
+
+assert(isinstance(im["string"], str))
+assert(im["string"] == "sample")
+
+assert(isinstance(im["int"], int))
+assert(im["int"] == 2)
+
+assert(isinstance(im["bool"], bool))
+assert(im["bool"] == True)
+
+assert(isinstance(im["struct"], ifxmap.TestStruct))
+assert(im["struct"].Value == 6)
+
+assert(isinstance(im["structPtr"], ifxmap.TestStruct))
+assert(im["structPtr"].Value == 12)
+
+assert(len(im) == 6)
+
+print("OK")

--- a/_examples/pointermap/pointermap.go
+++ b/_examples/pointermap/pointermap.go
@@ -1,0 +1,46 @@
+// Copyright 2015 The go-python Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pointermap
+
+type Options map[string]interface{}
+
+type Profile struct {
+	Name       string
+	Envs       map[string]Options
+}
+
+type Project struct {
+	Profile *Profile
+}
+
+func NewProject(name string) Project{
+	profile := Profile {
+		Name: name,
+		Envs: make(map[string]Options),
+	}
+	options := make(map[string]interface{})
+	options["dev"] = 4
+	profile.Envs["myPrjProfile"] = options
+	prj := Project {
+		Profile: &profile,
+	}
+
+	return prj
+}
+
+func GetOptions() map[string]interface{} {
+	retval := make(map[string]interface{})
+	retval["a"] = 1
+	retval["b"] = "2"
+	retval["c"] = true
+	return retval
+}
+
+func GetOptionsMap() map[string]Options {
+	retval := make(map[string]Options)
+	retval["opt"] = GetOptions()
+
+	return retval
+}

--- a/_examples/pointermap/test.py
+++ b/_examples/pointermap/test.py
@@ -1,0 +1,21 @@
+# Copyright 2015 The go-python Authors.  All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+import pointermap
+
+opt = pointermap.GetOptions()
+print("opt = %r" % (opt,))
+
+optmap = pointermap.GetOptionsMap()
+print("optmap['opt'] = %r" % (optmap['opt'],))
+
+#import pdb;pdb.set_trace()
+print("optmap = %r" % (optmap,))
+
+p = pointermap.NewProject("myproject")
+print("p = %r" % (p,))
+print("p.Name = %s" % (p.Name,))
+print("p.Envs = %s" % (p.Envs,))
+
+print("OK")

--- a/main_test.go
+++ b/main_test.go
@@ -37,9 +37,11 @@ var (
 		"_examples/pyerrors":    []string{"py2", "py3"},
 		"_examples/iface":       []string{"py3"}, // output order diff for 2, fails but actually works
 		"_examples/pointers":    []string{"py2", "py3"},
+		"_examples/pointermap":  []string{"py3"},
 		"_examples/arrays":      []string{"py2", "py3"},
 		"_examples/slices":      []string{"py2", "py3"},
 		"_examples/maps":        []string{"py2", "py3"},
+		"_examples/ifxmap":      []string{"py3"},
 		"_examples/gostrings":   []string{"py2", "py3"},
 		"_examples/rename":      []string{"py2", "py3"},
 		"_examples/lot":         []string{"py2", "py3"},
@@ -351,6 +353,22 @@ OK
 	})
 }
 
+func TestBindPointerMap(t *testing.T) {
+	// t.Parallel()
+	path := "_examples/pointermap"
+	testPkg(t, pkg{
+		path:   path,
+		lang:   features[path],
+		cmd:    "build",
+		extras: nil,
+		want: []byte(`s = pointers.S(2)
+s = pointers.S{Value=2, handle=1}
+s.Value = 2
+OK
+`),
+	})
+}
+
 func TestBindNamed(t *testing.T) {
 	// t.Parallel()
 	path := "_examples/named"
@@ -623,6 +641,22 @@ maps.Values from Go map: go.Slice_float64 len: 2 handle: 4 [3.0, 5.0]
 maps.Keys from Python dictionary: go.Slice_int len: 2 handle: 6 [1, 2]
 maps.Values from Python dictionary: go.Slice_float64 len: 2 handle: 8 [3.0, 5.0]
 deleted 1 from a: maps.Map_int_float64 len: 1 handle: 1 {2=5.0, }
+OK
+`),
+	})
+}
+
+func TestBindIfxMap(t *testing.T) {
+	// t.Parallel()
+	path := "_examples/ifxmap"
+	testPkg(t, pkg{
+		path:   path,
+		lang:   features[path],
+		cmd:    "build",
+		extras: nil,
+		want: []byte(`s = pointers.S(2)
+s = pointers.S{Value=2, handle=1}
+s.Value = 2
 OK
 `),
 	})


### PR DESCRIPTION
## Description of the change
Updates to make sure that when a go map is moved over to python, the type of its values is as expected. Also, checking for the map of string maps case.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
